### PR TITLE
ゲーム中にスコア更新、ゲームクリア時にトータルのスコアを出すように実装

### DIFF
--- a/Assets/Player/PlayerController.cs
+++ b/Assets/Player/PlayerController.cs
@@ -23,6 +23,7 @@ public class PlayerController : MonoBehaviour
   string nowAnime = "";
   string oldAnime = "";
   public static string gameState = "playing"; // ゲームの状態
+  public int score = 0;  // スコア
 
   // Start is called before the first frame update
   void Start()
@@ -133,6 +134,17 @@ public class PlayerController : MonoBehaviour
     else if (collision.gameObject.tag == "Dead")
     {
       GameOver();
+    }
+    else if (collision.gameObject.tag == "ScoreItem")
+    {
+      // スコアアイテム
+      // ItemDataを取得
+      ItemData item = collision.gameObject.GetComponent<ItemData>();
+      // スコアを得る
+      score = item.value;
+
+      // アイテムを削除
+      Destroy(collision.gameObject);
     }
   }
 

--- a/Assets/Prefabs/Canvas.prefab
+++ b/Assets/Prefabs/Canvas.prefab
@@ -80,6 +80,81 @@ MonoBehaviour:
   m_Text: '000
 
 '
+--- !u!1 &2579425640315398547
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8329119779732955915}
+  - component: {fileID: 2175694916484036763}
+  - component: {fileID: 623651527885192230}
+  m_Layer: 5
+  m_Name: ScoreBoard
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8329119779732955915
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2579425640315398547}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 7506654898342842361}
+  m_Father: {fileID: 5038385114118068609}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -252.1, y: -124.5}
+  m_SizeDelta: {x: 441.02704, y: 180.5758}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2175694916484036763
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2579425640315398547}
+  m_CullTransparentMesh: 0
+--- !u!114 &623651527885192230
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2579425640315398547}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 1b238d9a7d29e45dcba04c1e474fc172, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 1
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &5038385113821110553
 GameObject:
   m_ObjectHideFlags: 0
@@ -259,6 +334,7 @@ RectTransform:
   - {fileID: 5038385114210959084}
   - {fileID: 5038385114962275900}
   - {fileID: 6360456515553549114}
+  - {fileID: 8329119779732955915}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -347,6 +423,8 @@ MonoBehaviour:
   nextButton: {fileID: 5038385114173298078}
   timeBar: {fileID: 5950269247213408795}
   timeText: {fileID: 1921575434055683825}
+  scoreText: {fileID: 5999160923437774929}
+  stageScore: 0
 --- !u!114 &521791357826121584
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -879,3 +957,83 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &5999160923437774929
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7506654898342842361}
+  - component: {fileID: 8276250908490347360}
+  - component: {fileID: 2290024951390309769}
+  m_Layer: 5
+  m_Name: Scoretext
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7506654898342842361
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5999160923437774929}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 8329119779732955915}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -18.22}
+  m_SizeDelta: {x: 312.8, y: 78}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &8276250908490347360
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5999160923437774929}
+  m_CullTransparentMesh: 0
+--- !u!114 &2290024951390309769
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5999160923437774929}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 64
+    m_FontStyle: 1
+    m_BestFit: 0
+    m_MinSize: 6
+    m_MaxSize: 64
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: '000
+
+'

--- a/Assets/Prefabs/item_blue.prefab
+++ b/Assets/Prefabs/item_blue.prefab
@@ -1,0 +1,114 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &8332455255171395167
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8711204314798003828}
+  - component: {fileID: 8699313611987948541}
+  - component: {fileID: 8875892195785533643}
+  - component: {fileID: 6574026295970074228}
+  m_Layer: 0
+  m_Name: item_blue
+  m_TagString: ScoreItem
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8711204314798003828
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8332455255171395167}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 6.8259172, y: -0.3939005, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &8699313611987948541
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8332455255171395167}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 2
+  m_Sprite: {fileID: 21300000, guid: ebbff01de40314325a359ea9c19134ac, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 0.64, y: 0.64}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!58 &8875892195785533643
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8332455255171395167}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  serializedVersion: 2
+  m_Radius: 0.32
+--- !u!114 &6574026295970074228
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8332455255171395167}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d392fc45a98ea4308ac3fe9ac58ea5ee, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  value: 30

--- a/Assets/Prefabs/item_blue.prefab.meta
+++ b/Assets/Prefabs/item_blue.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: f9d325a153b334add8ba53a9a6281d49
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/item_green.prefab
+++ b/Assets/Prefabs/item_green.prefab
@@ -1,0 +1,114 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &5318465292925088022
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4897865039689510959}
+  - component: {fileID: 463798012268949391}
+  - component: {fileID: 4512092285200223730}
+  - component: {fileID: 457474447949577989}
+  m_Layer: 0
+  m_Name: item_green
+  m_TagString: ScoreItem
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4897865039689510959
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5318465292925088022}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 7.509205, y: -2.0594134, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &463798012268949391
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5318465292925088022}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 2
+  m_Sprite: {fileID: 21300000, guid: 593c0c122f6d54407ba17627ed7d8e38, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 0.64, y: 0.64}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!58 &4512092285200223730
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5318465292925088022}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  serializedVersion: 2
+  m_Radius: 0.32
+--- !u!114 &457474447949577989
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5318465292925088022}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d392fc45a98ea4308ac3fe9ac58ea5ee, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  value: 10

--- a/Assets/Prefabs/item_green.prefab.meta
+++ b/Assets/Prefabs/item_green.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 1e5f33b2b1b354348880186a09a27a02
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/item_red.prefab
+++ b/Assets/Prefabs/item_red.prefab
@@ -1,0 +1,114 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &895964547407210135
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8162540351073166747}
+  - component: {fileID: 4486008277147939267}
+  - component: {fileID: 5912046640146847295}
+  - component: {fileID: 4290611315651210649}
+  m_Layer: 0
+  m_Name: item_red
+  m_TagString: ScoreItem
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8162540351073166747
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 895964547407210135}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 5.8524942, y: -1.2196605, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &4486008277147939267
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 895964547407210135}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 2
+  m_Sprite: {fileID: 21300000, guid: de99c0dd9d32a416985c6ebe41b26b1c, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 0.64, y: 0.64}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!58 &5912046640146847295
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 895964547407210135}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  serializedVersion: 2
+  m_Radius: 0.32
+--- !u!114 &4290611315651210649
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 895964547407210135}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d392fc45a98ea4308ac3fe9ac58ea5ee, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  value: 50

--- a/Assets/Prefabs/item_red.prefab.meta
+++ b/Assets/Prefabs/item_red.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e0d603de0a80248b9971952a2025808a
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/item_white.prefab
+++ b/Assets/Prefabs/item_white.prefab
@@ -1,0 +1,114 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &8983639144070429903
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6079097522664745720}
+  - component: {fileID: 1670987246820075233}
+  - component: {fileID: 603350836499695610}
+  - component: {fileID: 1084345599513312701}
+  m_Layer: 0
+  m_Name: item_white
+  m_TagString: ScoreItem
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6079097522664745720
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8983639144070429903}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 9.986122, y: -1.8885915, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &1670987246820075233
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8983639144070429903}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 2
+  m_Sprite: {fileID: 21300000, guid: 0735be885df5145e2bddd4754fb06fe2, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 0.64, y: 0.64}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!58 &603350836499695610
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8983639144070429903}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  serializedVersion: 2
+  m_Radius: 0.32
+--- !u!114 &1084345599513312701
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8983639144070429903}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d392fc45a98ea4308ac3fe9ac58ea5ee, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  value: 100

--- a/Assets/Prefabs/item_white.prefab.meta
+++ b/Assets/Prefabs/item_white.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: f9884e39d5705419bbbb56da0ee0499e
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/BaseForcedScrollStage.unity
+++ b/Assets/Scenes/BaseForcedScrollStage.unity
@@ -558,12 +558,22 @@ PrefabInstance:
     - target: {fileID: 5038385114962275900, guid: 2c94e6b3c73ea4c588b276cb3d7359c9,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -214
+      value: -213.99997
       objectReference: {fileID: 0}
     - target: {fileID: 6360456515553549114, guid: 2c94e6b3c73ea4c588b276cb3d7359c9,
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -73.79999
+      objectReference: {fileID: 0}
+    - target: {fileID: 8329119779732955915, guid: 2c94e6b3c73ea4c588b276cb3d7359c9,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -224
+      objectReference: {fileID: 0}
+    - target: {fileID: 8329119779732955915, guid: 2c94e6b3c73ea4c588b276cb3d7359c9,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -93
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2c94e6b3c73ea4c588b276cb3d7359c9, type: 3}
@@ -1412,3 +1422,279 @@ Transform:
   m_Father: {fileID: 303822357}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &4797364213378871858
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4897865039689510959, guid: 1e5f33b2b1b354348880186a09a27a02,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 7.509205
+      objectReference: {fileID: 0}
+    - target: {fileID: 4897865039689510959, guid: 1e5f33b2b1b354348880186a09a27a02,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2.0594134
+      objectReference: {fileID: 0}
+    - target: {fileID: 4897865039689510959, guid: 1e5f33b2b1b354348880186a09a27a02,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4897865039689510959, guid: 1e5f33b2b1b354348880186a09a27a02,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4897865039689510959, guid: 1e5f33b2b1b354348880186a09a27a02,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4897865039689510959, guid: 1e5f33b2b1b354348880186a09a27a02,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4897865039689510959, guid: 1e5f33b2b1b354348880186a09a27a02,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4897865039689510959, guid: 1e5f33b2b1b354348880186a09a27a02,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 14
+      objectReference: {fileID: 0}
+    - target: {fileID: 4897865039689510959, guid: 1e5f33b2b1b354348880186a09a27a02,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4897865039689510959, guid: 1e5f33b2b1b354348880186a09a27a02,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4897865039689510959, guid: 1e5f33b2b1b354348880186a09a27a02,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5318465292925088022, guid: 1e5f33b2b1b354348880186a09a27a02,
+        type: 3}
+      propertyPath: m_Name
+      value: item_green
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1e5f33b2b1b354348880186a09a27a02, type: 3}
+--- !u!1001 &5023625812875893191
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 895964547407210135, guid: e0d603de0a80248b9971952a2025808a,
+        type: 3}
+      propertyPath: m_Name
+      value: item_red
+      objectReference: {fileID: 0}
+    - target: {fileID: 8162540351073166747, guid: e0d603de0a80248b9971952a2025808a,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 5.8524942
+      objectReference: {fileID: 0}
+    - target: {fileID: 8162540351073166747, guid: e0d603de0a80248b9971952a2025808a,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1.2196605
+      objectReference: {fileID: 0}
+    - target: {fileID: 8162540351073166747, guid: e0d603de0a80248b9971952a2025808a,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8162540351073166747, guid: e0d603de0a80248b9971952a2025808a,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8162540351073166747, guid: e0d603de0a80248b9971952a2025808a,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8162540351073166747, guid: e0d603de0a80248b9971952a2025808a,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8162540351073166747, guid: e0d603de0a80248b9971952a2025808a,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8162540351073166747, guid: e0d603de0a80248b9971952a2025808a,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 12
+      objectReference: {fileID: 0}
+    - target: {fileID: 8162540351073166747, guid: e0d603de0a80248b9971952a2025808a,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8162540351073166747, guid: e0d603de0a80248b9971952a2025808a,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8162540351073166747, guid: e0d603de0a80248b9971952a2025808a,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: e0d603de0a80248b9971952a2025808a, type: 3}
+--- !u!1001 &5733010526442554260
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 8332455255171395167, guid: f9d325a153b334add8ba53a9a6281d49,
+        type: 3}
+      propertyPath: m_Name
+      value: item_blue
+      objectReference: {fileID: 0}
+    - target: {fileID: 8711204314798003828, guid: f9d325a153b334add8ba53a9a6281d49,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 6.8259172
+      objectReference: {fileID: 0}
+    - target: {fileID: 8711204314798003828, guid: f9d325a153b334add8ba53a9a6281d49,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.3939005
+      objectReference: {fileID: 0}
+    - target: {fileID: 8711204314798003828, guid: f9d325a153b334add8ba53a9a6281d49,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8711204314798003828, guid: f9d325a153b334add8ba53a9a6281d49,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8711204314798003828, guid: f9d325a153b334add8ba53a9a6281d49,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8711204314798003828, guid: f9d325a153b334add8ba53a9a6281d49,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8711204314798003828, guid: f9d325a153b334add8ba53a9a6281d49,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8711204314798003828, guid: f9d325a153b334add8ba53a9a6281d49,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 13
+      objectReference: {fileID: 0}
+    - target: {fileID: 8711204314798003828, guid: f9d325a153b334add8ba53a9a6281d49,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8711204314798003828, guid: f9d325a153b334add8ba53a9a6281d49,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8711204314798003828, guid: f9d325a153b334add8ba53a9a6281d49,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: f9d325a153b334add8ba53a9a6281d49, type: 3}
+--- !u!1001 &7843045600809308547
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 6079097522664745720, guid: f9884e39d5705419bbbb56da0ee0499e,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 9.986122
+      objectReference: {fileID: 0}
+    - target: {fileID: 6079097522664745720, guid: f9884e39d5705419bbbb56da0ee0499e,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1.8885915
+      objectReference: {fileID: 0}
+    - target: {fileID: 6079097522664745720, guid: f9884e39d5705419bbbb56da0ee0499e,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6079097522664745720, guid: f9884e39d5705419bbbb56da0ee0499e,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6079097522664745720, guid: f9884e39d5705419bbbb56da0ee0499e,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6079097522664745720, guid: f9884e39d5705419bbbb56da0ee0499e,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6079097522664745720, guid: f9884e39d5705419bbbb56da0ee0499e,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6079097522664745720, guid: f9884e39d5705419bbbb56da0ee0499e,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 15
+      objectReference: {fileID: 0}
+    - target: {fileID: 6079097522664745720, guid: f9884e39d5705419bbbb56da0ee0499e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6079097522664745720, guid: f9884e39d5705419bbbb56da0ee0499e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6079097522664745720, guid: f9884e39d5705419bbbb56da0ee0499e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8983639144070429903, guid: f9884e39d5705419bbbb56da0ee0499e,
+        type: 3}
+      propertyPath: m_Name
+      value: item_white
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: f9884e39d5705419bbbb56da0ee0499e, type: 3}

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -19,6 +19,11 @@ public class GameManager : MonoBehaviour
   public GameObject timeText;  // 時間テキスト
   TimeController timeCnt;  // TimeController
 
+  // +++ スコア追加 +++
+  public GameObject scoreText;  // スコアテキスト
+  public static int totalScore;  // 合計スコア
+  public int stageScore = 0;  // ステージスコア
+
   // Start is called before the first frame update
   void Start()
   {
@@ -37,6 +42,9 @@ public class GameManager : MonoBehaviour
         timeBar.SetActive(false);  // 制限時間なしなら非表示
       }
     }
+
+    // +++ スコア追加 +++
+    UpdateScore();
   }
 
   // Update is called once per frame
@@ -57,7 +65,15 @@ public class GameManager : MonoBehaviour
       if (timeCnt != null)
       {
         timeCnt.isTimeOver = true;  // 時間カウント停止
+        // +++ スコア追加 +++
+        // 整数に代入することで少数を切り捨て
+        int time = (int)timeCnt.displayTime;
+        totalScore += time * 10;  // 残り時間をスコアに加算
       }
+      // +++ スコア追加 +++
+      totalScore += stageScore;
+      stageScore = 0;  // スコアリセット
+      UpdateScore(); // スコア更新
     }
     else if (PlayerController.gameState == "gameover")
     {
@@ -99,10 +115,24 @@ public class GameManager : MonoBehaviour
           }
         }
       }
+      // +++ スコア追加 +++
+      if (playerCnt.score != 0)
+      {
+        stageScore += playerCnt.score;  // 入手したスコアアイテムのスコアをステージスコアに加算
+        playerCnt.score = 0;  // スコアリセット
+        UpdateScore();
+      }
     }
   }
   void InactiveImage()
   {
     mainImage.SetActive(false);
+  }
+  // +++ スコア追加 +++
+  void UpdateScore()
+  {
+    // 
+    int score = stageScore + totalScore;
+    scoreText.GetComponent<Text>().text = score.ToString();
   }
 }

--- a/Assets/Scripts/ItemData.cs
+++ b/Assets/Scripts/ItemData.cs
@@ -1,0 +1,8 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class ItemData : MonoBehaviour
+{
+  public int value = 0;  // 整数値を設定できる
+}

--- a/Assets/Scripts/ItemData.cs.meta
+++ b/Assets/Scripts/ItemData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d392fc45a98ea4308ac3fe9ac58ea5ee
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -6,6 +6,7 @@ TagManager:
   tags:
   - Goal
   - Dead
+  - ScoreItem
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
## 実装内容
触れるとスコアが加算されるアイテムを用意

- ゲームプレイ中
  - アイテムに触れたらプレイヤーの持つスコアが加算され、GameManagerにてステージスコアに取り込まれる。
  - UI上のスコアにリアルタイムで反映される
- ゲームクリア後
  - カウントの残りを10倍した数値と、アイテムのスコアをすべてあわせたトータルスコアを算出し、UIに表示する